### PR TITLE
Update gem information

### DIFF
--- a/api-ai-ruby.gemspec
+++ b/api-ai-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/api-ai-ruby.rb
+++ b/lib/api-ai-ruby.rb
@@ -25,3 +25,6 @@ require 'api-ai-ruby/models/entry'
 require 'api-ai-ruby/models/entity'
 require 'api-ai-ruby/crud/contexts_request'
 require 'api-ai-ruby/crud/user_entity_request'
+
+module ApiAiRuby
+end

--- a/lib/api-ai-ruby/constants.rb
+++ b/lib/api-ai-ruby/constants.rb
@@ -14,7 +14,7 @@
 
 module ApiAiRuby
   class Constants
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
     DEFAULT_BASE_URL = 'https://api.api.ai/v1/'
     DEFAULT_API_VERSION = '20150910'
     DEFAULT_CLIENT_LANG = 'en'


### PR DESCRIPTION
I have experienced some problems with this gem (some Name Error problems, the Rails application wasn't able to load the gem on some cases), so I made this changes and they are working.

I saw on RubyGems that the current version of the gem is 2.1.0, but it was set on the constants as 2.0.0 so I changed that. Also I added the module to api-ai-ruby.rb and updated the minor Ruby version.